### PR TITLE
feat: add calendar event options and Gmail message management tools

### DIFF
--- a/src/mcp_gsuite/calendar.py
+++ b/src/mcp_gsuite/calendar.py
@@ -102,6 +102,10 @@ class CalendarService:
         send_notifications: bool = True,
         timezone: str | None = None,
         calendar_id: str = "primary",
+        transparency: str | None = None,
+        reminders: dict | None = None,
+        color_id: str | None = None,
+        recurrence: list[str] | None = None,
     ) -> dict | None:
         """
         Create a new calendar event.
@@ -115,6 +119,10 @@ class CalendarService:
             attendees (list, optional): List of attendee email addresses
             send_notifications (bool): Whether to send notifications to attendees
             timezone (str, optional): Timezone for the event (e.g. 'America/New_York')
+            transparency (str, optional): 'transparent' (free) or 'opaque' (busy)
+            reminders (dict, optional): Reminder config, e.g. {"useDefault": False, "overrides": []}
+            color_id (str, optional): Google Calendar color ID (1-11)
+            recurrence (list[str], optional): RRULE strings, e.g. ["RRULE:FREQ=WEEKLY;BYDAY=MO"]
 
         Returns:
             dict: Created event data or None if creation fails
@@ -139,8 +147,15 @@ class CalendarService:
             if description:
                 event["description"] = description
             if attendees:
-                # Type annotation to clarify the expected structure
                 event["attendees"] = [{"email": email} for email in attendees]  # type: ignore
+            if transparency is not None:
+                event["transparency"] = transparency
+            if reminders is not None:
+                event["reminders"] = reminders
+            if color_id is not None:
+                event["colorId"] = color_id
+            if recurrence is not None:
+                event["recurrence"] = recurrence
 
             # Create the event
             created_event = (
@@ -201,6 +216,10 @@ class CalendarService:
         send_notifications: bool = True,
         timezone: str | None = None,
         calendar_id: str = "primary",
+        transparency: str | None = None,
+        reminders: dict | None = None,
+        color_id: str | None = None,
+        recurrence: list[str] | None = None,
     ) -> dict | None:
         """
         Update an existing calendar event.
@@ -216,6 +235,10 @@ class CalendarService:
             send_notifications (bool): Whether to send notifications to attendees
             timezone (str, optional): Timezone for the event (e.g. 'America/New_York')
             calendar_id (str): Calendar ID (default: 'primary')
+            transparency (str, optional): 'transparent' (free) or 'opaque' (busy)
+            reminders (dict, optional): Reminder config, e.g. {"useDefault": False, "overrides": []}
+            color_id (str, optional): Google Calendar color ID (1-11)
+            recurrence (list[str], optional): RRULE strings, e.g. ["RRULE:FREQ=WEEKLY;BYDAY=MO"]
 
         Returns:
             dict: Updated event data or None if update fails
@@ -235,6 +258,14 @@ class CalendarService:
                 existing_event["description"] = description
             if attendees is not None:
                 existing_event["attendees"] = [{"email": email} for email in attendees]
+            if transparency is not None:
+                existing_event["transparency"] = transparency
+            if reminders is not None:
+                existing_event["reminders"] = reminders
+            if color_id is not None:
+                existing_event["colorId"] = color_id
+            if recurrence is not None:
+                existing_event["recurrence"] = recurrence
 
             # Update time fields if provided
             if start_time is not None:

--- a/src/mcp_gsuite/calendar_tools.py
+++ b/src/mcp_gsuite/calendar_tools.py
@@ -89,6 +89,26 @@ async def create_calendar_event(
     description: Annotated[str | None, "Optional description or details for the event."] = None,
     location: Annotated[str | None, "Optional location for the event."] = None,
     attendees: Annotated[list[str] | None, "Optional list of attendee email addresses."] = None,
+    timezone: Annotated[
+        str | None,
+        "IANA timezone name (e.g., 'America/Los_Angeles'). Defaults to UTC if omitted.",
+    ] = None,
+    transparency: Annotated[
+        str | None,
+        "Event visibility: 'transparent' (show as free) or 'opaque' (show as busy).",
+    ] = None,
+    reminders: Annotated[
+        dict | None,
+        "Reminder config, e.g. {\"useDefault\": false, \"overrides\": []} to disable all reminders.",
+    ] = None,
+    color_id: Annotated[
+        str | None,
+        "Google Calendar color ID (1-11).",
+    ] = None,
+    recurrence: Annotated[
+        list[str] | None,
+        "List of RRULE strings, e.g. [\"RRULE:FREQ=WEEKLY;BYDAY=MO\"].",
+    ] = None,
     ctx: Context | None = None,
 ) -> list[TextContent]:
     """Creates a new calendar event."""
@@ -101,7 +121,6 @@ async def create_calendar_event(
         # Extract date/time values properly depending on whether it's an all-day event or timed event
         start_time = start_datetime
         end_time = end_datetime
-        timezone = None  # Default timezone will be handled by the calendar service
 
         created_event = calendar_service.create_event(
             summary=summary,
@@ -112,6 +131,10 @@ async def create_calendar_event(
             attendees=attendees,
             calendar_id=calendar_id,
             timezone=timezone,
+            transparency=transparency,
+            reminders=reminders,
+            color_id=color_id,
+            recurrence=recurrence,
         )
 
         if not created_event:
@@ -189,6 +212,22 @@ async def update_calendar_event(
         str | None,
         "Timezone for the event (e.g., 'America/New_York', 'Asia/Tokyo').",
     ] = None,
+    transparency: Annotated[
+        str | None,
+        "Event visibility: 'transparent' (show as free) or 'opaque' (show as busy).",
+    ] = None,
+    reminders: Annotated[
+        dict | None,
+        "Reminder config, e.g. {\"useDefault\": false, \"overrides\": []} to disable all reminders.",
+    ] = None,
+    color_id: Annotated[
+        str | None,
+        "Google Calendar color ID (1-11).",
+    ] = None,
+    recurrence: Annotated[
+        list[str] | None,
+        "List of RRULE strings, e.g. [\"RRULE:FREQ=WEEKLY;BYDAY=MO\"].",
+    ] = None,
     ctx: Context | None = None,
 ) -> list[TextContent]:
     """Updates an existing calendar event. Only provided fields will be updated."""
@@ -209,6 +248,10 @@ async def update_calendar_event(
             attendees=attendees,
             timezone=timezone,
             calendar_id=calendar_id,
+            transparency=transparency,
+            reminders=reminders,
+            color_id=color_id,
+            recurrence=recurrence,
         )
 
         if updated_event:

--- a/src/mcp_gsuite/fast_server.py
+++ b/src/mcp_gsuite/fast_server.py
@@ -33,6 +33,8 @@ from .gmail_drive_tools import (
     save_gmail_attachment_to_drive,
 )
 from .gmail_tools import (
+    archive_gmail_message,
+    batch_modify_gmail_messages,
     bulk_get_gmail_emails,
     bulk_save_gmail_attachments,
     create_gmail_draft,
@@ -40,6 +42,8 @@ from .gmail_tools import (
     delete_gmail_draft,
     get_email_details,
     get_gmail_labels,
+    mark_gmail_message_read,
+    modify_gmail_message,
     query_gmail_emails,
 )
 from .settings import settings  # Import settings to ensure it's loaded
@@ -100,6 +104,16 @@ mcp.tool(description="Create a draft email in Gmail.")(create_gmail_draft)
 mcp.tool(description="Delete a draft email from Gmail.")(delete_gmail_draft)
 
 mcp.tool(description="Create a reply to an existing Gmail email message.")(create_gmail_reply)
+
+mcp.tool(description="Modify labels on a Gmail message (add or remove labels).")(modify_gmail_message)
+
+mcp.tool(description="Mark a Gmail message as read.")(mark_gmail_message_read)
+
+mcp.tool(description="Archive a Gmail message (remove from inbox).")(archive_gmail_message)
+
+mcp.tool(
+    description="Modify labels on multiple Gmail messages in a single batch request (max 1000)."
+)(batch_modify_gmail_messages)
 
 # get_gmail_attachment is deprecated - use save_gmail_attachment_to_drive instead
 # to avoid returning large base64 data that consumes context

--- a/src/mcp_gsuite/gmail.py
+++ b/src/mcp_gsuite/gmail.py
@@ -392,6 +392,73 @@ class GmailService:
             logging.error(traceback.format_exc())
             return None
 
+    def modify_message(
+        self,
+        message_id: str,
+        add_label_ids: list[str] | None = None,
+        remove_label_ids: list[str] | None = None,
+    ) -> dict | None:
+        """
+        Modify labels on a Gmail message.
+
+        Args:
+            message_id (str): The ID of the message to modify
+            add_label_ids (list[str], optional): Label IDs to add
+            remove_label_ids (list[str], optional): Label IDs to remove
+
+        Returns:
+            dict: Modified message data or None if modification fails
+        """
+        try:
+            body: dict = {}
+            if add_label_ids:
+                body["addLabelIds"] = add_label_ids
+            if remove_label_ids:
+                body["removeLabelIds"] = remove_label_ids
+
+            result = (
+                self.service.users()
+                .messages()
+                .modify(userId="me", id=message_id, body=body)
+                .execute()
+            )
+            return result
+        except Exception as e:
+            logging.error(f"Error modifying message {message_id}: {e!s}")
+            logging.error(traceback.format_exc())
+            return None
+
+    def batch_modify_messages(
+        self,
+        message_ids: list[str],
+        add_label_ids: list[str] | None = None,
+        remove_label_ids: list[str] | None = None,
+    ) -> bool:
+        """
+        Modify labels on multiple Gmail messages in a single request.
+
+        Args:
+            message_ids (list[str]): Message IDs to modify (max 1000)
+            add_label_ids (list[str], optional): Label IDs to add
+            remove_label_ids (list[str], optional): Label IDs to remove
+
+        Returns:
+            bool: True if modification was successful, False otherwise
+        """
+        try:
+            body: dict = {"ids": message_ids[:1000]}
+            if add_label_ids:
+                body["addLabelIds"] = add_label_ids
+            if remove_label_ids:
+                body["removeLabelIds"] = remove_label_ids
+
+            self.service.users().messages().batchModify(userId="me", body=body).execute()
+            return True
+        except Exception as e:
+            logging.error(f"Error batch modifying messages: {e!s}")
+            logging.error(traceback.format_exc())
+            return False
+
     def get_attachment(self, message_id: str, attachment_id: str) -> dict | None:
         """
         Retrieves a Gmail attachment by its ID.

--- a/src/mcp_gsuite/gmail_tools.py
+++ b/src/mcp_gsuite/gmail_tools.py
@@ -2,6 +2,7 @@ import json
 import logging
 from typing import Annotated
 
+from pydantic import BeforeValidator
 from fastmcp import Context
 from mcp.types import TextContent
 
@@ -10,6 +11,23 @@ from . import gmail as gmail_impl
 from .common import get_user_id_description
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_str_list(v: object) -> object:
+    """Accept a JSON-encoded string and parse it into a list before Pydantic validation."""
+    if isinstance(v, str):
+        try:
+            parsed = json.loads(v)
+            if isinstance(parsed, list):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+        return [v]
+    return v
+
+
+# Type alias for list[str] params that may arrive as JSON strings from MCP clients
+StrList = Annotated[list[str], BeforeValidator(_coerce_str_list)]
 
 
 # Gmail related tools
@@ -300,26 +318,11 @@ async def create_gmail_reply(
         raise RuntimeError(error_msg) from e
 
 
-def _ensure_list(value: list[str] | str | None) -> list[str] | None:
-    """Coerce a value to a list of strings. Handles JSON strings passed by MCP clients."""
-    if value is None:
-        return None
-    if isinstance(value, str):
-        try:
-            parsed = json.loads(value)
-            if isinstance(parsed, list):
-                return [str(item) for item in parsed]
-        except (json.JSONDecodeError, ValueError):
-            pass
-        return [value]
-    return value
-
-
 async def modify_gmail_message(
     user_id: Annotated[str, get_user_id_description()],
     message_id: Annotated[str, "The ID of the Gmail message to modify."],
-    add_label_ids: Annotated[list[str] | None, "Label IDs to add to the message."] = None,
-    remove_label_ids: Annotated[list[str] | None, "Label IDs to remove from the message."] = None,
+    add_label_ids: Annotated[StrList | None, "Label IDs to add to the message."] = None,
+    remove_label_ids: Annotated[StrList | None, "Label IDs to remove from the message."] = None,
     ctx: Context | None = None,
 ) -> list[TextContent]:
     """Modifies labels on a Gmail message (add or remove labels)."""
@@ -330,8 +333,8 @@ async def modify_gmail_message(
         gmail_service = gmail_impl.GmailService(g_service)
         result = gmail_service.modify_message(
             message_id=message_id,
-            add_label_ids=_ensure_list(add_label_ids),
-            remove_label_ids=_ensure_list(remove_label_ids),
+            add_label_ids=add_label_ids,
+            remove_label_ids=remove_label_ids,
         )
         if not result:
             if ctx:
@@ -378,9 +381,9 @@ async def archive_gmail_message(
 
 async def batch_modify_gmail_messages(
     user_id: Annotated[str, get_user_id_description()],
-    message_ids: Annotated[list[str], "List of Gmail message IDs to modify (max 1000)."],
-    add_label_ids: Annotated[list[str] | None, "Label IDs to add to all messages."] = None,
-    remove_label_ids: Annotated[list[str] | None, "Label IDs to remove from all messages."] = None,
+    message_ids: Annotated[StrList, "List of Gmail message IDs to modify (max 1000)."],
+    add_label_ids: Annotated[StrList | None, "Label IDs to add to all messages."] = None,
+    remove_label_ids: Annotated[StrList | None, "Label IDs to remove from all messages."] = None,
     ctx: Context | None = None,
 ) -> list[TextContent]:
     """Modifies labels on multiple Gmail messages in a single batch request."""
@@ -390,9 +393,9 @@ async def batch_modify_gmail_messages(
         g_service = auth_helper.get_gmail_service(user_id)
         gmail_service = gmail_impl.GmailService(g_service)
         success = gmail_service.batch_modify_messages(
-            message_ids=_ensure_list(message_ids) or [],
-            add_label_ids=_ensure_list(add_label_ids),
-            remove_label_ids=_ensure_list(remove_label_ids),
+            message_ids=message_ids,
+            add_label_ids=add_label_ids,
+            remove_label_ids=remove_label_ids,
         )
         if success:
             if ctx:

--- a/src/mcp_gsuite/gmail_tools.py
+++ b/src/mcp_gsuite/gmail_tools.py
@@ -300,6 +300,101 @@ async def create_gmail_reply(
         raise RuntimeError(error_msg) from e
 
 
+async def modify_gmail_message(
+    user_id: Annotated[str, get_user_id_description()],
+    message_id: Annotated[str, "The ID of the Gmail message to modify."],
+    add_label_ids: Annotated[list[str] | None, "Label IDs to add to the message."] = None,
+    remove_label_ids: Annotated[list[str] | None, "Label IDs to remove from the message."] = None,
+    ctx: Context | None = None,
+) -> list[TextContent]:
+    """Modifies labels on a Gmail message (add or remove labels)."""
+    try:
+        if ctx:
+            await ctx.info(f"Modifying message {message_id} for user {user_id}")
+        g_service = auth_helper.get_gmail_service(user_id)
+        gmail_service = gmail_impl.GmailService(g_service)
+        result = gmail_service.modify_message(
+            message_id=message_id,
+            add_label_ids=add_label_ids,
+            remove_label_ids=remove_label_ids,
+        )
+        if not result:
+            if ctx:
+                await ctx.error(f"Failed to modify message {message_id}")
+            return [TextContent(type="text", text=f"Failed to modify message {message_id}.")]
+        if ctx:
+            await ctx.info(f"Successfully modified message {message_id}")
+        return [TextContent(type="text", text=json.dumps(result, indent=2))]
+    except Exception as e:
+        logger.error(f"Error in modify_gmail_message for {user_id}: {e}", exc_info=True)
+        error_msg = f"Error modifying message: {e}"
+        if ctx:
+            await ctx.error(error_msg)
+        raise RuntimeError(error_msg) from e
+
+
+async def mark_gmail_message_read(
+    user_id: Annotated[str, get_user_id_description()],
+    message_id: Annotated[str, "The ID of the Gmail message to mark as read."],
+    ctx: Context | None = None,
+) -> list[TextContent]:
+    """Marks a Gmail message as read by removing the UNREAD label."""
+    return await modify_gmail_message(
+        user_id=user_id,
+        message_id=message_id,
+        remove_label_ids=["UNREAD"],
+        ctx=ctx,
+    )
+
+
+async def archive_gmail_message(
+    user_id: Annotated[str, get_user_id_description()],
+    message_id: Annotated[str, "The ID of the Gmail message to archive."],
+    ctx: Context | None = None,
+) -> list[TextContent]:
+    """Archives a Gmail message by removing it from the inbox."""
+    return await modify_gmail_message(
+        user_id=user_id,
+        message_id=message_id,
+        remove_label_ids=["INBOX"],
+        ctx=ctx,
+    )
+
+
+async def batch_modify_gmail_messages(
+    user_id: Annotated[str, get_user_id_description()],
+    message_ids: Annotated[list[str], "List of Gmail message IDs to modify (max 1000)."],
+    add_label_ids: Annotated[list[str] | None, "Label IDs to add to all messages."] = None,
+    remove_label_ids: Annotated[list[str] | None, "Label IDs to remove from all messages."] = None,
+    ctx: Context | None = None,
+) -> list[TextContent]:
+    """Modifies labels on multiple Gmail messages in a single batch request."""
+    try:
+        if ctx:
+            await ctx.info(f"Batch modifying {len(message_ids)} messages for user {user_id}")
+        g_service = auth_helper.get_gmail_service(user_id)
+        gmail_service = gmail_impl.GmailService(g_service)
+        success = gmail_service.batch_modify_messages(
+            message_ids=message_ids,
+            add_label_ids=add_label_ids,
+            remove_label_ids=remove_label_ids,
+        )
+        if success:
+            if ctx:
+                await ctx.info(f"Successfully batch modified {len(message_ids)} messages")
+            return [TextContent(type="text", text=f"Successfully modified {len(message_ids)} messages.")]
+        else:
+            if ctx:
+                await ctx.error(f"Failed to batch modify messages for user {user_id}")
+            return [TextContent(type="text", text="Failed to batch modify messages.")]
+    except Exception as e:
+        logger.error(f"Error in batch_modify_gmail_messages for {user_id}: {e}", exc_info=True)
+        error_msg = f"Error batch modifying messages: {e}"
+        if ctx:
+            await ctx.error(error_msg)
+        raise RuntimeError(error_msg) from e
+
+
 async def get_gmail_attachment(
     user_id: Annotated[str, get_user_id_description()],
     message_id: Annotated[str, "The ID of the Gmail message containing the attachment."],

--- a/src/mcp_gsuite/gmail_tools.py
+++ b/src/mcp_gsuite/gmail_tools.py
@@ -300,6 +300,21 @@ async def create_gmail_reply(
         raise RuntimeError(error_msg) from e
 
 
+def _ensure_list(value: list[str] | str | None) -> list[str] | None:
+    """Coerce a value to a list of strings. Handles JSON strings passed by MCP clients."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, list):
+                return [str(item) for item in parsed]
+        except (json.JSONDecodeError, ValueError):
+            pass
+        return [value]
+    return value
+
+
 async def modify_gmail_message(
     user_id: Annotated[str, get_user_id_description()],
     message_id: Annotated[str, "The ID of the Gmail message to modify."],
@@ -315,8 +330,8 @@ async def modify_gmail_message(
         gmail_service = gmail_impl.GmailService(g_service)
         result = gmail_service.modify_message(
             message_id=message_id,
-            add_label_ids=add_label_ids,
-            remove_label_ids=remove_label_ids,
+            add_label_ids=_ensure_list(add_label_ids),
+            remove_label_ids=_ensure_list(remove_label_ids),
         )
         if not result:
             if ctx:
@@ -375,9 +390,9 @@ async def batch_modify_gmail_messages(
         g_service = auth_helper.get_gmail_service(user_id)
         gmail_service = gmail_impl.GmailService(g_service)
         success = gmail_service.batch_modify_messages(
-            message_ids=message_ids,
-            add_label_ids=add_label_ids,
-            remove_label_ids=remove_label_ids,
+            message_ids=_ensure_list(message_ids) or [],
+            add_label_ids=_ensure_list(add_label_ids),
+            remove_label_ids=_ensure_list(remove_label_ids),
         )
         if success:
             if ctx:


### PR DESCRIPTION
## Summary

- **Calendar enhancements**: Add timezone, transparency, reminders, color_id, and recurrence parameters to `create_calendar_event` and `update_calendar_event`
- **Gmail message management**: Add `modify_gmail_message`, `mark_gmail_message_read`, `archive_gmail_message`, and `batch_modify_gmail_messages` tools
- **Bug fix**: MCP clients pass JSON arrays as strings, which Pydantic rejects before the function body runs. Fixed with `BeforeValidator` to coerce label ID params at the type level

## Test plan

- [ ] Verify calendar event creation with new optional params (timezone, reminders, recurrence)
- [ ] Verify Gmail modify/archive/mark-read tools work with real messages
- [ ] Verify label ID params accept both `["INBOX"]` and `'["INBOX"]'` (string-encoded arrays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)